### PR TITLE
cpus: share clock between QEMU/libcpu

### DIFF
--- a/include/cpu/cpus.h
+++ b/include/cpu/cpus.h
@@ -36,20 +36,19 @@ typedef struct TimersState {
     int32_t cpu_ticks_enabled;
     int64_t dummy;
 
-    /* slow down vm clock by a factor x */
-    int32_t clock_scale_enable;
-    int32_t clock_scale;
+    /* slow down vm clock by a factor x. This is shared with QEMU over the libs2e interface */
+    int32_t cpu_clock_scale_factor;
+
     int64_t cpu_clock_prev;
     int64_t cpu_clock_prev_scaled;
-
 } TimersState;
-
-void cpu_enable_scaling(int scale);
 
 extern TimersState timers_state;
 
-int64_t cpu_get_ticks(void);
-void cpu_enable_ticks(void);
-void cpu_disable_ticks(void);
+/*
+ * Called from S2EExecutor to scale down the clock when performing symbolic
+ * execution.
+ */
+void cpu_enable_scaling(int scale);
 
 #endif

--- a/include/cpu/kvm.h
+++ b/include/cpu/kvm.h
@@ -329,6 +329,9 @@ struct kvm_run {
         struct kvm_sync_regs regs;
         char padding[1024];
     } s;
+
+    /* Share timer's clock scaling between QEMU and libcpu */
+    int32_t cpu_clock_scale_factor;
 };
 
 /* for KVM_REGISTER_COALESCED_MMIO / KVM_UNREGISTER_COALESCED_MMIO */
@@ -758,8 +761,11 @@ struct kvm_ppc_smmu_info {
 #define KVM_CAP_PPC_ENABLE_HCALL 104
 #define KVM_CAP_CHECK_EXTENSION_VM 105
 
-/***** custom capability for symbolic execution support *****/
+/***** custom capabilities for symbolic execution support *****/
 #define KVM_CAP_MEM_RW 1021
+
+/* This capability allows a clock to be slowed down via a clock scaling factor */
+#define KVM_CAP_CPU_CLOCK_SCALE 1022
 
 /* This capability forces CPU exit */
 #define KVM_CAP_FORCE_EXIT 255

--- a/include/timer.h
+++ b/include/timer.h
@@ -63,6 +63,10 @@ void libcpu_run_timers(CPUClock *clock);
 void libcpu_run_all_timers(void);
 void init_clocks(void);
 
+int64_t cpu_get_ticks(void);
+void cpu_enable_ticks(void);
+void cpu_disable_ticks(void);
+
 static inline CPUTimer *libcpu_new_timer_ms(CPUClock *clock, CPUTimerCB *cb, void *opaque) {
     return libcpu_new_timer(clock, SCALE_MS, cb, opaque);
 }


### PR DESCRIPTION
Previously QEMU and libcpu maintained their own timer state. However, when performing symbolic execution the scaling factor would only be applied to the libcpu clock, and **not** the QEMU clock. This meant that the QEMU clock continued to run at normal speed and hence would constantly interrupt symbolic execution (in KLEE), causing S2E to "get stuck".

To fix this problem we share a single timer state between QEMU and libcpu via the KVM interface. So when we apply scaling in libcpu, the QEMU clock will also be scaled. Because of the shared clock all accesses to the timer state occur via pointers and are controlled by a lock.